### PR TITLE
Make parse syslog line faster

### DIFF
--- a/benchmarks/01-parse.pl
+++ b/benchmarks/01-parse.pl
@@ -28,6 +28,13 @@ timethese(10_000, {
     'Epoch Only' => sub {
         local $Parse::Syslog::Line::DateTimeCreate = 0;
         local $Parse::Syslog::Line::EpochCreate    = 1;
+        local $Parse::Syslog::Line::DateTimeStr    = 0;
+        parse_syslog_line($_) for @msgs
+    },
+    'Epoch + Date' => sub {
+        local $Parse::Syslog::Line::DateTimeCreate = 0;
+        local $Parse::Syslog::Line::EpochCreate    = 1;
+        local $Parse::Syslog::Line::DateTimeStr    = 1;
         parse_syslog_line($_) for @msgs
     },
     'Minimalistic Data' => sub {

--- a/lib/Parse/Syslog/Line.pm
+++ b/lib/Parse/Syslog/Line.pm
@@ -13,6 +13,7 @@ use HTTP::Date;
 our $VERSION        = '3.3';
 
 our $DateTimeCreate    = 1;
+our $DateTimeStr       = 1;
 our $ExtractProgram    = 1;
 our $FmtDate;
 our $EpochCreate       = 0;
@@ -490,7 +491,7 @@ sub parse_syslog_line {
                     $msg{epoch} -= $offset if $offset;
                 }
             }
-            $msg{datetime_str} = HTTP::Date::time2iso($msg{epoch});
+            $msg{datetime_str} = HTTP::Date::time2iso($msg{epoch}) if $DateTimeStr;
         }
     }
 


### PR DESCRIPTION
Howdy!

So, after some benchmarking, it turned up that parse_syslog_line() was around 30-40% of our processing time; primarily in HTTP::Date (and Time::Local inside).

The branch does three things:
1. Changes parse_syslog_line from using several substitutions into a single regex. This _might_ be a bit of a speedup in some situations, but in reality it was primarily done to allow the next optimization.
2. Since 1. is already matching and capturing the parts of the date, no need to use HTTP::Date to parse the string and turn it into an epoch -- instead, we can use POSIX::mktime(), which is in C, to significantly cut down on processing time. NYTProf was profiling each call to str2time() at 102µs/call, while the mktime() version profiles at around 7µs/call, including the extra code to handle fractional seconds.
3. Added an option (DateTimeStr) to toggle creating datetime_str if we are under EpochCreate. This is missing docs and tests right now, sorry :)
