### PR TITLE
Bugfix: IETF-syslog-proto23 Fixes

### DIFF
--- a/benchmarks/02-benchsmarter.pl
+++ b/benchmarks/02-benchsmarter.pl
@@ -21,6 +21,11 @@ const my @msgs => (
     q|<134>Jan 1 11:28:13 filer-201.example.com [filer-201: scsitarget.ispfct.targetReset:notice]: FCP Target 0c: Target was Reset by the Initiator at Port Id: 0x11000 (WWPN 5001438021e071ec)|,
     q|2016-11-19T20:50:01.749659+01:00 janus CROND[14400]: (root) CMD (/usr/lib64/sa/sa1 1 1)|,
     q|2015 Nov 13 13:40:01 ether rsyslogd-2177: imuxsock begins to drop messages from pid 17840 due to rate-limit|,
+    q|2015 Nov 13 13:40:01 ether application: JSON log is: {"src_ip":"1.2.3.4","src_port":35235}|,
+    q|2015 Nov 13 13:40:01 ether application: this is words with some splunk k/v at the end: k1=v1, k2=v2, k3=v3|,
+    q|May 24 09:14:21 deprecation GoogleSoftwareUpdateAgent[22548]: 2018-05-24 09:14:21.050 GoogleSoftwareUpdateAgent[22548/0x70000b057000] [lvl=2] -[KSAgentApp(PrivateMethods) setUpLoggerOutputForVerboseMode:] Agent default/global settings: <KSAgentSettings:0x1003390a0 bundleID=com.google.Keystone.Agent lastCheck=2018-05-24 00:07:32 +0000 lastServerCheck=2018-05-24 00:07:31 +0000 lastCheckStart=2018-05-24 16:14:19 +0000 checkInterval=18000.000000 uiDisplayInterval=604800.000000 sleepInterval=1800.000000 jitterInterval=900 maxRunInterval=0.000000 isConsoleUser=1 ticketStorePath=/Users/brad/Library/Google/GoogleSoftwareUpdate/TicketStore/Keystone.ticketstore runMode=3 daemonUpdateEngineBrokerServiceName=com.google.Keystone.Daemon.UpdateEngine daemonAdministrationServiceName=com.google.Keystone.Daemon.Administration alwaysPromptForUpdates=0 lastUIDisplayed=(null) alwaysShowStatusItem=0 updateCheckTag=(null) printResults=NO userInitiated=NO>|,
+    q|2015 Nov 13 13:40:01 ether application: [lvl=2] [foo x=1] some context [bar x=3 t=4]|,
+    q|2015 Nov 13 13:40:01 ether application: [prop@12345 x="2"] some context|,
 );
 
 my $last = '';
@@ -57,6 +62,13 @@ $bench->add_instances(
     Dumbbench::Instance::PerlSub->new(
         name => 'Defaults',
         code => sub { $stub->('Defaults') },
+    ),
+    Dumbbench::Instance::PerlSub->new(
+        name => 'RFC5424Strict',
+        code => sub {
+            local $Parse::Syslog::Line::RFC5424StructuredDataStrict = 1;
+            $stub->('RFC5424Strict')
+        },
     ),
     Dumbbench::Instance::PerlSub->new(
         name => 'NormalizeToUTC',

--- a/lib/Parse/Syslog/Line.pm
+++ b/lib/Parse/Syslog/Line.pm
@@ -183,8 +183,8 @@ our %EXPORT_TAGS = (
 # Regex to Extract Data
 const my %RE => (
     IPv4            => qr/(?>(?:[0-9]{1,3}\.){3}[0-9]{1,3})/,
-    preamble        => qr/^\<(\d+)\>(\d{0,2})\s*/,
-    year            => qr/^(\d{4}) /,
+    preamble        => qr/^\<(\d+)\>(\d{0,2}(?=\s))?\s*/,
+    year            => qr/^(\d{4})\s/,
     date            => qr/(?<date>[A-Za-z]{3}\s+[0-9]+\s+[0-9]{1,2}(?:\:[0-9]{2}){1,2})/,
     date_long => qr/
             (?:[0-9]{4}\s+)?                # Year: Because, Cisco
@@ -205,7 +205,7 @@ const my %RE => (
             (?:[Zz]|[+\-][0-9]{2}\:[0-9]{2}) # UTC Offset +DD:MM or 'Z' indicating UTC-0
     )/x,
     host            => qr/\s*(?<host>[^:\s]+)\s+/,
-    cisco_hates_you => qr/\s*[0-9]*:\s+/,
+    cisco_detection => qr/\s*[0-9]*:\s+/,
     program_raw     => qr/\s*([^\[][^:]+)(?<program_sep>:|\s-)\s+/,
     program_name    => qr/(.[^\[\(\ ]*)(.*)/,
     program_sub     => qr/(?>\(([^\)]+)\))/,
@@ -604,8 +604,8 @@ sub parse_syslog_line {
     }
 
     # Find weird cisco dates
-    if( $raw_string =~ s/^$RE{cisco_hates_you}//o ) {
-        # Yes, Cisco adds a second timestamp to it's messages, because it hates you.
+    if( $raw_string =~ s/^$RE{cisco_detection}//o ) {
+        # Yes, Cisco adds a second timestamp to it's messages, because ...
         if( $raw_string =~ s/^$RE{date_long}//o ) {
             # Cisco encodes the status of NTP in the second datestamp, so let's pass it back
             if ( my $ntp = $1 ) {


### PR DESCRIPTION
This should solve an issue with IETF-syslog-proto23 parsing. The issue exists with the "version" detection code when the datestamps are in RFC-3339 format. This PR uses a positive look-ahead to make sure the version number is followed by a space as per the IETF draft.