### PR TITLE
Maintenance Work to Normalize Minimum Perl and Improve Benchmarks

### DIFF
--- a/benchmarks/00-defaults.pl
+++ b/benchmarks/00-defaults.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+use v5.14;
 use warnings;
 use Dumbbench;
 use Const::Fast;

--- a/benchmarks/01-parse.pl
+++ b/benchmarks/01-parse.pl
@@ -1,8 +1,7 @@
 #!perl
 
-use strict;
+use v5.14;
 use warnings;
-use feature 'state';
 use Benchmark qw/timethese cmpthese/;
 use Const::Fast;
 use Parse::Syslog::Line;

--- a/benchmarks/02-benchsmarter.pl
+++ b/benchmarks/02-benchsmarter.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+use v5.14;
 use warnings;
 use Const::Fast;
 use Dumbbench;

--- a/benchmarks/xt-date-parsing-iso.pl
+++ b/benchmarks/xt-date-parsing-iso.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-use strict;
+use v5.14;
 use warnings;
 
 use Benchmark qw(cmpthese);

--- a/benchmarks/xt-date-parsing-legacy.pl
+++ b/benchmarks/xt-date-parsing-legacy.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-use strict;
+use v5.14;
 use warnings;
 
 use Benchmark qw(cmpthese);

--- a/bin/parse-syslog-line.pl
+++ b/bin/parse-syslog-line.pl
@@ -1,7 +1,7 @@
 #!perl
 # PODNAME: parse-syslog-line.pl
 # ABSTRACT: Parse a syslog message and display the structured data
-use strict;
+use v5.14;
 use warnings;
 
 use Data::Printer;
@@ -30,10 +30,10 @@ my ($opt,$usage) = describe_options("%c %o",
     ['Output Format'],
     ['format' => 'hidden', {
         one_of => [
-            [ print  => 'Format with Data::Printer' ],
-            [ json   => 'Format as JSON, minified' ],
-            [ pretty => 'Format as JSON, pretty' ],
-            [ yaml   => 'Format as YAML' ],
+            [ 'print|ddp' => 'Format with Data::Printer' ],
+            [ 'json|jq|j' => 'Format as JSON, minified' ],
+            [ pretty      => 'Format as JSON, pretty' ],
+            [ 'yaml|yml'  => 'Format as YAML' ],
         ],
         default => 'print',
     }],


### PR DESCRIPTION
* `use v5.14` everywhere
* Update CLI options to `parse-syslog-line.pl`
* Update the `01-parse.pl` benchmark to be more 